### PR TITLE
Update to new VarMINT syntax for interiorResidual and strongResidual

### DIFF
--- a/demos/heartValve.py
+++ b/demos/heartValve.py
@@ -263,7 +263,7 @@ v,q = split(vq)
 up_t = timeInt_f.xdot_alpha()
 u_t = uPart(up_t)
 cutFunc = Function(Vscalar)
-res_f = interiorResidual(u_alpha,p,v,q,rho,mu,mesh,u_t=u_t,Dt=Dt,dx=dx,
+res_f = interiorResidual(u_alpha,p,v,q,rho,mu,mesh,v_t=u_t,Dt=Dt,dy=dx,
                          stabScale=stabScale(cutFunc,stabEps))
 n = FacetNormal(mesh)
 res_f += stableNeumannBC(inflowTraction,rho,u_alpha,v,n,

--- a/demos/manufacturedSolution.py
+++ b/demos/manufacturedSolution.py
@@ -312,10 +312,11 @@ u_alpha = uPart(up_alpha)
 p = up[3]
 u_t_alpha = uPart(updot_alpha)
 cutFunc = Function(Vscalar)
-f_f,_ = strongResidual(u_exact(x_f),p_exact(x_f),mu,rho,u_t=u_t_exact(x_f))
+zero = Constant(d*(0,))
+f_f,_ = strongResidual(u_exact(x_f),p_exact(x_f),x_f,zero,mu,rho,u_t_exact(x_f),zero)
 f_f /= rho
 res_f = interiorResidual(u_alpha,p,v,q,rho,mu,mesh,
-                         u_t=u_t_alpha,Dt=Dt,dx=dx,f=f_f,
+                         v_t=u_t_alpha,Dt=Dt,dy=dx,f=f_f,
                          stabScale=stabScale(cutFunc,stabEps))
 
 # Flag vertical sides for weakBCs:

--- a/demos/valve2D.py
+++ b/demos/valve2D.py
@@ -234,7 +234,7 @@ p = up[3]
 u_t_alpha = uPart(updot_alpha)
 cutFunc = Function(Vscalar)
 res_f = interiorResidual(u_alpha,p,v,q,rho,mu,mesh,
-                         u_t=u_t_alpha,Dt=Dt,dx=dx,
+                         v_t=u_t_alpha,Dt=Dt,dy=dx,
                          stabScale=stabScale(cutFunc,stabEps))
 
 # Flag vertical sides for weakBCs:


### PR DESCRIPTION
I did not update all of the references from `u` to `v` for velocity but as of this commit, the demos work with the updated version of VarMINT.